### PR TITLE
Zero the string to be displayed on the dialogue box after leaving the…

### DIFF
--- a/Assets/Scripts/Dialogue.cs
+++ b/Assets/Scripts/Dialogue.cs
@@ -64,6 +64,7 @@ public class Dialogue : MonoBehaviour
     public void zeroText() //empties the dialogue box
     {
         dialogueTextUI.text = "";
+        dialogueToSay = "";
         gameObject.SetActive(false);
     }
 }


### PR DESCRIPTION
Fixed a bug where walking out of a NPC with the dialogue open and going to another would concat the strings in the dialogue message. Properly empties the string every time you leave the NPCs range.